### PR TITLE
Use seperate commands for better visibility in CI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,4 +3,5 @@ machine:
     version: 7.0.11
 test:
   override:
-    - composer test
+    - phpunit
+    - php-cs-fixer fix --dryrun


### PR DESCRIPTION
Using seperate commands provides better visibility of failed tests in
Circle CI.